### PR TITLE
Fix error :  `((: CHECK == : syntax error: operand expected (error token is "== ")`

### DIFF
--- a/ETCHING/etching
+++ b/ETCHING/etching
@@ -1093,7 +1093,7 @@ else
 
 	## sorting bam file
 	CHECK=$($SAMTOOLS sort 2>&1 | grep "\-o" | grep "final output to stdout" | wc -l )
-	if (( CHECK == ))
+	if [[ "${CHECK}" -eq  0 ]]
 	then
 	    cmd="${SAMTOOLS} sort -@ ${THREADS} ${PREFIX}.bam -o ${PREFIX}.sort.bam"
 	else


### PR DESCRIPTION
Hi, thank you for creating etching. I just tried to use it by cloning + compile the git repo.
But I got the following error:

`ETCHING/bin/etching: line 1096: ((: CHECK == : syntax error: operand expected (error token is "== ")`

I hope the following PR would fix the error.